### PR TITLE
Buffer index out of bounds fixed and jumps added.

### DIFF
--- a/interpreter.py
+++ b/interpreter.py
@@ -2,7 +2,7 @@ import re
 
 _word_delimiter = re.compile(r'[^a-z]')
 
-def combine_results(results):
+def check_results(results):
     if len(results) == 0:
         return True
     if len(results) == 1:
@@ -34,15 +34,19 @@ class CButNot:
     def set_register(self, value):
         self.registers[_registers[self.current_register]] = value
 
+    def run(self):
+        while self.step():
+            pass
     def step(self):
         idx = self.command_idx + 1
         cmd = self.commands[idx]
         while isinstance(cmd, str): idx += 1
         if isinstance(cmd, tuple):
             self.execute_command(*cmd)
-        elif isinstance(cmd, list) and self.check_jump(cmd[1]):
+        elif isinstance(cmd, list) and self.check_jump(cmd[1:]):
             idx = self.commands.index[cmd[0]]
         self.command_idx = idx
+        return idx + 1 < len(self.commands)
 
     def execute_command(self, prefix, register, postfix):
         self.current_register = _registers.index(register)
@@ -66,8 +70,13 @@ class CButNot:
     def execute_cmd(self, cmd, position, value):
         return self.cmds[cmd](position, value)
     def check_jump(self, operations):
-        results = list(map(lambda op: execute_command(*op)))
-        return combine_results(results)
+        results = []
+        for ops in operations:
+            result = 0
+            for op in ops:
+                result = execute_command(*op)
+            results.append(result)
+        return check_results(results)
 
     def cmd_idx(self, position, value):
         added_value = self.stack.pop() if position == 'prefix' else 1

--- a/interpreter.py
+++ b/interpreter.py
@@ -2,13 +2,25 @@ import re
 
 _word_delimiter = re.compile(r'[^a-z]')
 
+def combine_results(results):
+    if len(results) == 0:
+        return True
+    if len(results) == 1:
+        return results[0] != 0
+    if len(results) == 2:
+        return bool(results[0] and results[1])
+    if len(results) == 3:
+        return bool(results[int(bool(results[0]))+1])
+
 _registers = ['+', '-', '*', '/', '%', '&', '|', '^', '<<', '>>']
 class CButNot:
-    def __init__(self, *args, **kwargs):
+    def __init__(self, commands, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.commands = commands
+        self.command_idx = commands.index("main")
         self.registers = {}
         self.stack = []
-        self.buffer = []
+        self.buffer = {}
         self.current_register = -1
         self.cmds = {}
         for member in dir(self):
@@ -22,12 +34,23 @@ class CButNot:
     def set_register(self, value):
         self.registers[_registers[self.current_register]] = value
 
+    def step(self):
+        idx = self.command_idx + 1
+        cmd = self.commands[idx]
+        while isinstance(cmd, str): idx += 1
+        if isinstance(cmd, tuple):
+            self.execute_command(*cmd)
+        elif isinstance(cmd, list) and self.check_jump(cmd[1]):
+            idx = self.commands.index[cmd[0]]
+        self.command_idx = idx
+
     def execute_command(self, prefix, register, postfix):
         self.current_register = _registers.index(register)
         value = self.registers.get(register, 0)
         value = self.execute_fragment(prefix, 'prefix', value)
         value = self.execute_fragment(postfix, 'postfix', value)
         self.registers[register] = value
+        return value
     def execute_fragment(self, fragment, position, value):
         while True:
             while fragment and not fragment[:1].isalpha():
@@ -42,6 +65,9 @@ class CButNot:
         return value
     def execute_cmd(self, cmd, position, value):
         return self.cmds[cmd](position, value)
+    def check_jump(self, operations):
+        results = list(map(lambda op: execute_command(*op)))
+        return combine_results(results)
 
     def cmd_idx(self, position, value):
         added_value = self.stack.pop() if position == 'prefix' else 1
@@ -55,7 +81,7 @@ class CButNot:
     def cmd_tbl(self, position, value):
         if position == 'prefix':
             self.stack.append(value)
-            return self.buffer[value]
+            return self.buffer.get(value, 0)
         else:
             address = self.stack.pop()
             self.buffer[address] = value


### PR DESCRIPTION
While it's still untested, it should be possible to do both now. Additional combining operations for conditional jumps are still required.
Also, I forgot to mention in the commit, but the interpreter must now be constructed with a list of instruction, and can be executed with step(). I'll add a run() that just steps until the program ends soon.